### PR TITLE
Added --coverage-file / codescan.coveragefile support

### DIFF
--- a/cmd/portage/cli/v0/pipelines.go
+++ b/cmd/portage/cli/v0/pipelines.go
@@ -72,6 +72,9 @@ func newRunCommand() *cobra.Command {
 	codeScanCmd.Flags().Bool("semgrep-experimental", false, "Enable the use of the semgrep experimental CLI")
 	_ = viper.BindPFlag("codescan.semgrepexperimental", codeScanCmd.Flags().Lookup("semgrep-experimental"))
 
+	codeScanCmd.Flags().String("coverage-file", "", "An externally generated code coverage file to validate")
+	_ = viper.BindPFlag("codescan.coveragefile", codeScanCmd.Flags().Lookup("coverage-file"))
+
 	// run deploy
 	deployCmd := newBasicCommand("deploy", "Beta Feature: VALIDATION ONLY - run gatecheck validate on artifacts from previous pipelines", runDeploy)
 	deployCmd.Flags().String("gatecheck-config", "", "gatecheck configuration file")

--- a/pkg/pipelines/config.go
+++ b/pkg/pipelines/config.go
@@ -54,6 +54,7 @@ type configCodeScan struct {
 	SemgrepRules        string `mapstructure:"semgrepRules"`
 	SemgrepExperimental bool   `mapstructure:"semgrepExperimental"`
 	SemgrepSrcDir       string `mapstructure:"semgrepSrcDir"`
+	CoverageFile        string `mapstructure:"coverageFile"`
 }
 
 type configImagePublish struct {
@@ -271,6 +272,14 @@ var metaConfig = []metaConfigField{
 		ActionType:      "Bool",
 		Default:         false,
 		Description:     "Enable the use of the semgrep experimental CLI",
+	},
+	{
+		Key:             "codescan.coveragefile",
+		Env:             "PORTAGE_CODE_SCAN_COVERAGE_FILE",
+		ActionInputName: "coverage_file",
+		ActionType:      "String",
+		Default:         "",
+		Description:     "An externally generated code coverage file to validate",
 	},
 	{
 		Key:             "codescan.semgrepsrcdir",

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -93,6 +93,7 @@ type MetaConfig struct {
 	CodeScanSemgrepSrcDir             MetaField
 	CodeScanGitleaksSrcDir            MetaField
 	CodeScanSnykFilename              MetaField
+	CodeScanCoverageFile              MetaField
 	CodeScanSnykSrcDir                MetaField
 	ImagePublishEnabled               MetaField
 	ImagePublishBundleTag             MetaField
@@ -453,6 +454,17 @@ func NewMetaConfig() *MetaConfig {
 			ActionInputName: "snyk_code_filename",
 			ActionType:      "String",
 			DefaultValue:    "code-scan-report.snyk.sarif.json",
+			stringDecoder:   stringToStringDecoder,
+			cobraFunc:       stringVarCobraFunc,
+		},
+		CodeScanCoverageFile: MetaField{
+			FlagValueP:      new(string),
+			FlagName:        "coverage-file",
+			FlagDesc:        "An externally generated code coverage file to validate",
+			EnvKey:          "PORTAGE_CODE_SCAN_COVERAGE_FILE",
+			ActionInputName: "code_coverage_file",
+			ActionType:      "String",
+			DefaultValue:    "",
 			stringDecoder:   stringToStringDecoder,
 			cobraFunc:       stringVarCobraFunc,
 		},


### PR DESCRIPTION
Currently protage expects a code coverage report to be generated separately by a process not executed by portage. This option enables portage to include such a file in the artifact bundle and apply gatecheck validation to it.

Also configurable via PORTAGE_CODE_SCAN_COVERAGE_FILE