### PR TITLE
Move to loading the configuration once at the portage command level. 

### DIFF
--- a/.github/workflows/manual-delivery.yaml
+++ b/.github/workflows/manual-delivery.yaml
@@ -54,5 +54,7 @@ jobs:
         run: |
           echo "## Docker Action Image Build and Push Summary" >> $GITHUB_STEP_SUMMARY
           echo ":white_check_mark: Docker Action Image Build and Push" >> $GITHUB_STEP_SUMMARY
-          echo ":white_check_mark: Image (Docker CLI): ghcr.io/easy-up/portage:${{ steps.vars.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
-          echo ":white_check_mark: Image (Podman CLI): ghcr.io/easy-up/portage:podman-${{ steps.vars.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          # echo ":white_check_mark: Image (Docker CLI): ghcr.io/easy-up/portage:${{ steps.vars.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          # echo ":white_check_mark: Image (Podman CLI): ghcr.io/easy-up/portage:podman-${{ steps.vars.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          echo ":white_check_mark: Image (Docker CLI): ghcr.io/easy-up/portage:${GITHUB_SHA::8}" >> $GITHUB_STEP_SUMMARY
+          echo ":white_check_mark: Image (Podman CLI): ghcr.io/easy-up/portage:podman-${GITHUB_SHA::8}" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ test/artifacts
 artifacts
 libpod/
 .env.local
+.env
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ test/.artifacts
 test/artifacts
 artifacts
 libpod/
-
+.env.local
 dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,10 @@ WORKDIR /app
 
 ENV PORTAGE_CODE_SCAN_SEMGREP_EXPERIMENTAL="true"
 
+# Create non-root user and group
+RUN addgroup -S portage && adduser -S portage -G portage
+USER portage
+
 ENTRYPOINT ["portage"]
 
 LABEL org.opencontainers.image.title="portage-docker"
@@ -144,7 +148,8 @@ LABEL org.opencontainers.image.title="portage-podman"
 
 FROM portage-base
 
-# Install docker CLI
+USER root
 RUN apk update && apk add --no-cache docker-cli-buildx
+USER portage
 
 LABEL org.opencontainers.image.title="portage-docker"

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,8 +122,11 @@ LABEL io.artifacthub.package.license="Apache-2.0"
 
 FROM portage-base AS portage-podman
 
-# Install podman CLIs
-RUN apk update && apk add --no-cache podman fuse-overlayfs
+USER root
+# Update repositories and install packages
+RUN apk add --no-cache --update-cache \
+    podman \
+    fuse-overlayfs
 
 COPY docker/storage.conf /etc/containers/
 COPY docker/containers.conf /etc/containers/
@@ -134,15 +137,17 @@ RUN addgroup -S podman && adduser -S podman -G podman && \
 
 COPY docker/rootless-containers.conf /home/podman/.config/containers/containers.conf
 
-RUN mkdir -p /home/podman/.local/share/containers
-RUN chown podman:podman -R /home/podman
+RUN mkdir -p /home/podman/.local/share/containers && \
+    chown podman:podman -R /home/podman && \
+    mkdir -p /var/lib/clamav && \
+    chown podman /var/lib/clamav && \
+    chown podman /etc/clamav && \
+    chmod g+w /var/lib/clamav
 
 VOLUME /var/lib/containers
 VOLUME /home/podman/.local/share/containers
 
-RUN mkdir -p /var/lib/clamav
-RUN chown podman /var/lib/clamav && chown podman /etc/clamav
-RUN chmod g+w /var/lib/clamav
+USER podman
 
 LABEL org.opencontainers.image.title="portage-podman"
 

--- a/README.md
+++ b/README.md
@@ -52,15 +52,17 @@ go build -ldflags="-X 'main.cliVersion=$(git describe --tags)' -X 'main.gitCommi
 ```
 
 
-## Running A Pipeline
+## Getting Details of the Portage Pipeline Tooling
 
-You can run the executable directory
+To view tooling details, run the following command:
 
 ```bash
 portage run debug
 ```
 
 ## Configuring a Pipeline
+
+Portage uses a number of configuration sources to determine the behavior of the pipeline.  The order of precedence is as follows:
 
 Configuration Options:
 
@@ -77,6 +79,12 @@ Configuration Order-of-Precedence:
 3. Config File Value
 4. Default Value
 
+The recommended way to configure portage is to create a `.portage.yml` file in the root of your project.  To generate a sample configuration file, run the following command:
+
+```bash
+portage config init .portage.yml
+```
+
 Note: `(none)` means unset, left blank
 
 | Config Key                        | Environment Variable                     | Default Value                        | Description                                                                        |
@@ -87,8 +95,8 @@ Note: `(none)` means unset, left blank
 | codescan.semgrepfilename          | PORTAGE_CODE_SCAN_SEMGREP_FILENAME       | semgrep-sast-report.json             | The filename for the semgrep SAST report - must contain 'semgrep'                  |
 | codescan.semgreprules             | PORTAGE_CODE_SCAN_SEMGREP_RULES          | p/default                            | Semgrep ruleset manual override                                                    |
 | codescan.semgrepexperimental      | PORTAGE_CODE_SCAN_SEMGREP_EXPERIMENTAL   | false                                | Enable the use of the semgrep experimental CLI                                     |
-| deploy.enabled                    | PORTAGE_IMAGE_PUBLISH_ENABLED            | 1                                    | Enable/Disable the deploy pipeline                                                 |
-| deploy.gatecheckconfigfilename    | PORTAGE_DEPLOY_GATECHECK_CONFIG_FILENAME | -                                    | The filename for the gatecheck config                                              |
+| deploy.enabled                    | PORTAGE_IMAGE_PUBLISH_ENABLED            | 1                                    | Enable/Disable the publishing to a registry pipeline                                                 |
+| deploy.gatecheckconfigfilename    | PORTAGE_DEPLOY_GATECHECK_CONFIG_FILENAME | .gatecheck.yml                                    | The filename for the gatecheck config                                              |
 | gatecheckbundlefilename           | PORTAGE_GATECHECK_BUNDLE_FILENAME        | artifacts/gatecheck-bundle.tar.gz    | The filename for the gatecheck bundle, a validatable archive of security artifacts |
 | imagebuild.args                   | PORTAGE_IMAGE_BUILD_ARGS                 | -                                    | Comma seperated list of build time variables                                       |
 | imagebuild.builddir               | PORTAGE_IMAGE_BUILD_DIR                  | .                                    | The build directory to using during an image build                                 |
@@ -107,6 +115,14 @@ Note: `(none)` means unset, left blank
 | imagescan.grypefilename           | PORTAGE_IMAGE_SCAN_GRYPE_FILENAME        | grype-vulnerability-report-full.json | The filename for the grype vulnerability report - must contain 'grype'             |
 | imagescan.syftfilename            | PORTAGE_IMAGE_SCAN_SYFT_FILENAME         | syft-sbom-report.json                | The filename for the syft SBOM report - must contain 'syft'                        |
 
+The portage pipeline is broken into a number of stages.  Below are the stages and their purpose:
+
+- `code-scan`: Scans the application code for secrets
+- `image-build`: Builds the application image
+- `image-scan`: Scans the application image for vulnerabilities
+- `image-publish`: Publishes the application image to a registry
+
+Note you cannot run image scan or publish without running the image build stage.
 
 ## Running in Docker
 

--- a/cmd/portage/cli/v0/helper.go
+++ b/cmd/portage/cli/v0/helper.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"strings"
-	"portage/pkg/pipelines"
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/spf13/cobra"
@@ -115,48 +113,6 @@ func ListConfig(w io.Writer, v *viper.Viper) error {
 			return err
 		}
 	}
-	return nil
-}
-
-// LoadOrDefault will use the default values in v if filename is blank
-//
-// Caller should pass in a new config object
-func LoadOrDefault(filename string, config *pipelines.Config, v *viper.Viper) error {
-	slog.Debug("load configuration from file", "filename", filename)
-	if filename == "" {
-		slog.Debug("no filename given, load from env, cli flags, and then defaults")
-		return loadWithoutConfigFile(config, v)
-	}
-
-	v.SetConfigFile(filename)
-
-	err := v.ReadInConfig()
-	if err != nil {
-		slog.Error("viper read in config failed", "filename", filename)
-		return errors.New("config file failed to load.")
-	}
-
-	slog.Debug("unmarshal into config object")
-	if err := v.Unmarshal(config); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func loadWithoutConfigFile(config *pipelines.Config, v *viper.Viper) error {
-	var configNotFoundErr *viper.ConfigFileNotFoundError
-	err := v.ReadInConfig()
-	if err != nil && errors.As(err, &configNotFoundErr) {
-		slog.Error("viper read in config failed", "error", err)
-		return errors.New("config file failed to load.")
-	}
-
-	slog.Debug("unmarshal into config object")
-	if err := v.Unmarshal(config); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/cmd/portage/cli/v0/pipelines.go
+++ b/cmd/portage/cli/v0/pipelines.go
@@ -135,15 +135,10 @@ func runDebug(cmd *cobra.Command, _ []string) error {
 
 func runDeploy(cmd *cobra.Command, _ []string) error {
 	dryRunEnabled, _ := cmd.Flags().GetBool("dry-run")
-
-	v := viper.GetViper()
-	configFilename := v.GetString("config")
-
 	config := new(pipelines.Config)
-	if err := LoadOrDefault(configFilename, config, viper.GetViper()); err != nil {
+	if err := viper.Unmarshal(config); err != nil {
 		return err
 	}
-
 	return deployPipeline(cmd.OutOrStdout(), cmd.ErrOrStderr(), config, dryRunEnabled)
 }
 
@@ -151,14 +146,10 @@ func runImageBuild(cmd *cobra.Command, _ []string) error {
 	dryRunEnabled, _ := cmd.Flags().GetBool("dry-run")
 	cliInterface, _ := cmd.Flags().GetString("cli-interface")
 
-	v := viper.GetViper()
-	configFilename := v.GetString("config")
-
 	config := new(pipelines.Config)
-	if err := LoadOrDefault(configFilename, config, v); err != nil {
+	if err := viper.Unmarshal(config); err != nil {
 		return err
 	}
-
 	return imageBuildPipeline(cmd.OutOrStdout(), cmd.ErrOrStderr(), config, dryRunEnabled, cliInterface)
 }
 
@@ -166,11 +157,8 @@ func runImageScan(cmd *cobra.Command, _ []string) error {
 	dryRunEnabled, _ := cmd.Flags().GetBool("dry-run")
 	cliInterface, _ := cmd.Flags().GetString("cli-interface")
 
-	v := viper.GetViper()
-	configFilename := v.GetString("config")
-
 	config := new(pipelines.Config)
-	if err := LoadOrDefault(configFilename, config, v); err != nil {
+	if err := viper.Unmarshal(config); err != nil {
 		return err
 	}
 
@@ -181,11 +169,8 @@ func runimagePublish(cmd *cobra.Command, _ []string) error {
 	dryRunEnabled, _ := cmd.Flags().GetBool("dry-run")
 	cliInterface, _ := cmd.Flags().GetString("cli-interface")
 
-	v := viper.GetViper()
-	configFilename := v.GetString("config")
-
 	config := new(pipelines.Config)
-	if err := LoadOrDefault(configFilename, config, viper.GetViper()); err != nil {
+	if err := viper.Unmarshal(config); err != nil {
 		return err
 	}
 	return imagePublishPipeline(cmd.OutOrStdout(), cmd.ErrOrStderr(), config, dryRunEnabled, cliInterface)
@@ -194,14 +179,10 @@ func runimagePublish(cmd *cobra.Command, _ []string) error {
 func runCodeScan(cmd *cobra.Command, _ []string) error {
 	dryRunEnabled, _ := cmd.Flags().GetBool("dry-run")
 
-	v := viper.GetViper()
-	configFilename := v.GetString("config")
-
 	config := new(pipelines.Config)
-	if err := LoadOrDefault(configFilename, config, viper.GetViper()); err != nil {
+	if err := viper.Unmarshal(config); err != nil {
 		return err
 	}
-
 	return codeScanPipeline(cmd.OutOrStdout(), cmd.ErrOrStderr(), config, dryRunEnabled)
 }
 

--- a/cmd/portage/cli/v0/pipelines.go
+++ b/cmd/portage/cli/v0/pipelines.go
@@ -78,7 +78,9 @@ func newRunCommand() *cobra.Command {
 	// run deploy
 	deployCmd := newBasicCommand("deploy", "Beta Feature: VALIDATION ONLY - run gatecheck validate on artifacts from previous pipelines", runDeploy)
 	deployCmd.Flags().String("gatecheck-config", "", "gatecheck configuration file")
+	deployCmd.Flags().Bool("submit", false, "submit artifacts to configured API endpoint")
 	_ = viper.BindPFlag("deploy.gatecheckconfigfilename", deployCmd.Flags().Lookup("gatecheck-config"))
+	_ = viper.BindPFlag("deploy.submit", deployCmd.Flags().Lookup("submit"))
 
 	// run image-delivery
 

--- a/cmd/portage/cli/v0/root.go
+++ b/cmd/portage/cli/v0/root.go
@@ -14,7 +14,8 @@ var (
 )
 
 func NewPortageCommand() *cobra.Command {
-	viper.SetConfigName("portage")
+	viper.SetConfigName(".portage")
+	viper.SetConfigType("yml")
 	viper.AddConfigPath(".")
 	pipelines.BindViper(viper.GetViper())
 

--- a/justfile
+++ b/justfile
@@ -2,18 +2,9 @@ INSTALL_DIR := env('INSTALL_DIR', '/usr/local/bin')
 IMAGE_NAME := "ghcr.io/easy-up/portage"
 
 # build portage binary
-build-exp:
-    mkdir -p bin
-    go build -ldflags=" -X 'main.experimentalCLIv1="1"' -X 'main.cliVersion=$(git describe --tags)' -X 'main.gitCommit=$(git rev-parse HEAD)' -X 'main.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)' -X 'main.gitDescription=$(git log -1 --pretty=%B)'" -o ./bin ./cmd/portage
-
-# build and install binary
-install-exp: build-exp
-    cp ./bin/portage {{ INSTALL_DIR }}/portage
-
-# build portage binary
 build:
     mkdir -p bin
-    go build -ldflags="-X 'main.cliVersion=$(git describe --tags)' -X 'main.gitCommit=$(git rev-parse HEAD)' -X 'main.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)' -X 'main.gitDescription=$(git log -1 --pretty=%B)'" -o ./bin ./cmd/portage
+    go build -ldflags="-X 'main.cliVersion=$(git describe --tags)' -X 'main.gitCommit=$(git rev-parse HEAD)' -X 'main.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)' -X 'main.gitDescription=$(git log -1 --pretty=%B | tr \' _)'" -o ./bin ./cmd/portage
 
 # build docker image for local use
 docker-build-local:

--- a/pkg/pipelines/code-scan.go
+++ b/pkg/pipelines/code-scan.go
@@ -51,7 +51,7 @@ func (p *CodeScan) preRun() error {
 
 	if err := MakeDirectoryP(p.config.ArtifactDir); err != nil {
 		slog.Error("failed to create artifact directory", "name", p.config.ArtifactDir)
-		return errors.New("Code Scan Pipeline failed to run.")
+		return errors.New("code Scan Pipeline failed to run")
 	}
 
 	p.runtime.gitleaksFilename = path.Join(p.config.ArtifactDir, p.config.CodeScan.GitleaksFilename)
@@ -88,7 +88,7 @@ func (p *CodeScan) Run() error {
 	}
 
 	if err := p.preRun(); err != nil {
-		return fmt.Errorf("Code Scan Pipeline Pre-Run Failed: %v", err)
+		return fmt.Errorf("code Scan Pipeline Pre-Run Failed: %v", err)
 	}
 
 	fmt.Fprintln(p.Stdout, "******* Portage CD Code Scan Pipeline [Run] *******")

--- a/pkg/pipelines/config.go
+++ b/pkg/pipelines/config.go
@@ -28,6 +28,11 @@ type Config struct {
 	Deploy                  configDeploy       `mapstructure:"deploy"`
 }
 
+type webhookConfig struct {
+	Url              string `mapstructure:"url"`
+	AuthorizationVar string `mapstructure:"authorizationVar"`
+}
+
 type configImageBuild struct {
 	Enabled      bool     `mapstructure:"enabled"`
 	BuildDir     string   `mapstructure:"buildDir"`
@@ -65,9 +70,9 @@ type configImagePublish struct {
 }
 
 type configDeploy struct {
-	Enabled                 bool   `mapstructure:"enabled"`
-	GatecheckConfigFilename string `mapstructure:"gatecheckConfigFilename"`
-	Submit                  bool   `mapstructure:"submit"`
+	Enabled                 bool            `mapstructure:"enabled"`
+	GatecheckConfigFilename string          `mapstructure:"gatecheckConfigFilename"`
+	SuccessWebhooks         []webhookConfig `mapstructure:"successWebhooks"`
 }
 
 // metaConfigField is used to map viper values to env variables and their associated default values

--- a/pkg/pipelines/config.go
+++ b/pkg/pipelines/config.go
@@ -67,6 +67,7 @@ type configImagePublish struct {
 type configDeploy struct {
 	Enabled                 bool   `mapstructure:"enabled"`
 	GatecheckConfigFilename string `mapstructure:"gatecheckConfigFilename"`
+	Submit                  bool   `mapstructure:"submit"`
 }
 
 // metaConfigField is used to map viper values to env variables and their associated default values

--- a/pkg/pipelines/config.go
+++ b/pkg/pipelines/config.go
@@ -335,6 +335,7 @@ type defaultValues struct {
 
 // Add this after type definitions but before metaConfig
 var defaults = map[string]defaultValues{
+	"config":                  {value: ".portage.yml", configPath: ""},
 	"imagetag":                {value: "my-app:latest", configPath: "ImageTag"},
 	"artifactdir":             {value: "artifacts", configPath: "ArtifactDir"},
 	"gatecheckbundlefilename": {value: "gatecheck-bundle.tar.gz", configPath: "GatecheckBundleFilename"},

--- a/pkg/pipelines/debug.go
+++ b/pkg/pipelines/debug.go
@@ -31,7 +31,7 @@ func (d *Debug) Run() error {
 	wd, err := os.Getwd()
 	if err != nil {
 		slog.Error("cannot get current working directory", "error", err)
-		return errors.New("Debug Pipeline failed to Run.")
+		return errors.New("debug Pipeline failed to Run")
 	}
 	slog.Info(fmt.Sprintf("Current directory: %s", wd))
 

--- a/pkg/pipelines/deploy.go
+++ b/pkg/pipelines/deploy.go
@@ -122,12 +122,17 @@ func (p *Deploy) Run() error {
 	}
 
 	if p.config.Deploy.Submit {
+		configPath := gatecheckConfigPath
+		if p.config.Deploy.GatecheckConfigFilename != "" {
+			configPath = p.config.Deploy.GatecheckConfigFilename
+		}
+
 		err = shell.GatecheckSubmit(
 			shell.WithDryRun(p.DryRunEnabled),
 			shell.WithStderr(p.Stderr),
 			shell.WithStdout(p.Stdout),
 			shell.WithTargetFile(p.runtime.bundleFilename),
-			shell.WithConfigFile(gatecheckConfigPath),
+			shell.WithConfigFile(configPath),
 		)
 		if err != nil {
 			return mkDeploymentError(err)

--- a/pkg/pipelines/deploy.go
+++ b/pkg/pipelines/deploy.go
@@ -4,13 +4,14 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"github.com/jarxorg/tree"
-	"gopkg.in/yaml.v3"
 	"io"
 	"log/slog"
 	"os"
 	"path"
 	"portage/pkg/shell"
+
+	"github.com/jarxorg/tree"
+	"gopkg.in/yaml.v3"
 )
 
 type Deploy struct {
@@ -54,18 +55,17 @@ func (p *Deploy) Run() error {
 		return nil
 	}
 	if err := p.preRun(); err != nil {
-		return errors.New("Deploy Pipeline failed, pre-run error. See logs for details.")
+		return errors.New("deploy Pipeline failed, pre-run error. See logs for details")
 	}
 
 	slog.Warn("deployment pipeline is a beta feature. Only gatecheck validation will be conducted.")
 
 	gatecheckConfigPath := path.Join(p.config.ArtifactDir, "gatecheck-config.yml")
 	gatecheckConfig, err := os.OpenFile(gatecheckConfigPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
-	defer gatecheckConfig.Close()
-
 	if err != nil {
 		return mkDeploymentError(err)
 	}
+	defer gatecheckConfig.Close()
 
 	if p.config.Deploy.GatecheckConfigFilename != "" {
 		customConfigFile, err := os.ReadFile(p.config.Deploy.GatecheckConfigFilename)

--- a/pkg/pipelines/deploy.go
+++ b/pkg/pipelines/deploy.go
@@ -121,5 +121,18 @@ func (p *Deploy) Run() error {
 		return mkDeploymentError(err)
 	}
 
+	if p.config.Deploy.Submit {
+		err = shell.GatecheckSubmit(
+			shell.WithDryRun(p.DryRunEnabled),
+			shell.WithStderr(p.Stderr),
+			shell.WithStdout(p.Stdout),
+			shell.WithTargetFile(p.runtime.bundleFilename),
+			shell.WithConfigFile(gatecheckConfigPath),
+		)
+		if err != nil {
+			return mkDeploymentError(err)
+		}
+	}
+
 	return nil
 }

--- a/pkg/pipelines/image-publish.go
+++ b/pkg/pipelines/image-publish.go
@@ -54,7 +54,7 @@ func (p *ImagePublish) Run() error {
 	)
 	if err != nil {
 		slog.Error("failed to push image tag to registry", "image_tag", p.config.ImageTag)
-		return errors.New("Image Publish Pipeline failed.")
+		return errors.New("image Publish Pipeline failed")
 	}
 
 	if p.config.ImagePublish.BundleTag == "" {
@@ -73,7 +73,7 @@ func (p *ImagePublish) Run() error {
 	if err != nil {
 		slog.Error("failed to push image artifact bundle to registry",
 			"image_tag", p.config.ImagePublish.BundleTag, "bundle_filename", bundleFilename)
-		return errors.New("Image Publish Pipeline failed.")
+		return errors.New("image Publish Pipeline failed")
 	}
 
 	return nil

--- a/pkg/pipelines/image-scan.go
+++ b/pkg/pipelines/image-scan.go
@@ -67,7 +67,7 @@ func (p *ImageScan) preRun() error {
 
 	if err := MakeDirectoryP(p.config.ArtifactDir); err != nil {
 		slog.Error("failed to create artifact directory", "name", p.config.ArtifactDir)
-		return errors.New("Code Scan Pipeline failed to run.")
+		return errors.New("code Scan Pipeline failed to run")
 	}
 
 	p.runtime.syftFilename = path.Join(p.config.ArtifactDir, p.config.ImageScan.SyftFilename)
@@ -127,7 +127,7 @@ func (p *ImageScan) Run() error {
 	}
 
 	if err := p.preRun(); err != nil {
-		return fmt.Errorf("Image Scan Pipeline Pre-Run Failed: %v", err)
+		return fmt.Errorf("image Scan Pipeline Pre-Run Failed: %v", err)
 	}
 
 	fmt.Fprintln(p.Stdout, "******* Portage CD Image Scan Pipeline [Run] *******")

--- a/pkg/shell/gatecheck.go
+++ b/pkg/shell/gatecheck.go
@@ -76,3 +76,9 @@ func GatecheckValidate(options ...OptionFunc) error {
 	cmd := exec.Command("gatecheck", args...)
 	return run(cmd, o)
 }
+
+func GatecheckSubmit(options ...OptionFunc) error {
+	o := newOptions(options...)
+	cmd := exec.Command("gatecheck", "submit", "--config", o.configFilename, o.targetFilename)
+	return run(cmd, o)
+}

--- a/pkg/shell/gatecheck.go
+++ b/pkg/shell/gatecheck.go
@@ -79,6 +79,7 @@ func GatecheckValidate(options ...OptionFunc) error {
 
 func GatecheckSubmit(options ...OptionFunc) error {
 	o := newOptions(options...)
-	cmd := exec.Command("gatecheck", "submit", "--config", o.configFilename, o.targetFilename)
+	// TODO: remove verbose once we are at MVP
+	cmd := exec.Command("gatecheck", "submit", "--config", o.configFilename, o.targetFilename, "--verbose")
 	return run(cmd, o)
 }

--- a/pkg/shell/gatecheck.go
+++ b/pkg/shell/gatecheck.go
@@ -76,10 +76,3 @@ func GatecheckValidate(options ...OptionFunc) error {
 	cmd := exec.Command("gatecheck", args...)
 	return run(cmd, o)
 }
-
-func GatecheckSubmit(options ...OptionFunc) error {
-	o := newOptions(options...)
-	// TODO: remove verbose once we are at MVP
-	cmd := exec.Command("gatecheck", "submit", "--config", o.configFilename, o.targetFilename, "--verbose")
-	return run(cmd, o)
-}


### PR DESCRIPTION
Portage will now load configuration to the viper instance at the newportagecommand instantiation.  Subsequent pipeline trigger calls will use the same config.  Also fixed it so that the call "portage config init" will create the default .portage.yml file in the directory that it is called.  I also fixed the "portage config vars" command.