### PR TITLE
Gatecheck gitcontext logging improvements

### DIFF
--- a/.custom-gatecheck.yml
+++ b/.custom-gatecheck.yml
@@ -1,0 +1,27 @@
+gitleaks:
+    limitEnabled: false
+grype:
+    epssRiskAcceptance:
+        enabled: true
+        score: 0.001
+    severityLimit:
+        critical:
+            enabled: true
+            limit: 0
+        high:
+            enabled: true
+            limit: 7
+semgrep:
+    impactRiskAcceptance:
+        enabled: true
+        low: true
+    severityLimit:
+        error:
+            enabled: true
+            limit: 5
+version: "1"
+api:
+  enabled: true
+  endpoint: "http://localhost:5168/Build/SubmitArtifacts"
+  skipVerify: true
+  authorizationVar: "DEPLOY_WEBHOOK_AUTH_TOKEN"

--- a/.portage.yml
+++ b/.portage.yml
@@ -1,0 +1,49 @@
+# Base Configuration
+version: "1"
+imageTag: "ghcr.io/easy-up/portage-cd:latest"  # The full image tag for the target container image (e.g. my-org/my-app:latest)
+artifactDir: "artifacts"   # Directory for generated artifacts (e.g. ./artifacts) 
+gatecheckBundleFilename: "gatecheck-bundle.tar.gz"  # Filename for the gatecheck bundle (e.g. gatecheck-bundle.tar.gz)
+
+# Image Build Configuration
+imageBuild:
+  enabled: true           # Enable/Disable the image build pipeline (true/false)
+  buildDir: "."          # Build directory for image (e.g. ./cmd/portage)
+  dockerfile: "Dockerfile" # Dockerfile to use (e.g. ./cmd/portage/Dockerfile)
+  platform: ""           # Target platform (e.g. linux/amd64, linux/arm64)
+  target: ""            # Target stage for multi-stage builds (e.g. build, test, publish)
+  cacheTo: ""           # Cache export location (e.g. type=local,dest=path)
+  cacheFrom: ""         # Cache import location (e.g. type=local,src=path)  
+  squashLayers: false   # Whether to squash layers (true/false)
+  args: {}              # Build arguments (e.g. BUILD_ARGS=--build-arg=key=value)
+
+# Image Scan Configuration
+imageScan:
+  enabled: true           # Enable/Disable the image scan pipeline (true/false)
+  syftFilename: "syft-sbom-report.json" # Filename for the syft sbom report (e.g. syft-sbom-report.json)
+  grypeConfigFilename: "" # Filename for the grype config (e.g. grype-config.json)
+  grypeFilename: "grype-vulnerability-report-full.json" # Filename for the grype vulnerability report (e.g. grype-vulnerability-report-full.json)
+  clamavFilename: "clamav-virus-report.txt" # Filename for the clamav virus report (e.g. clamav-virus-report.txt)
+
+# Code Scan Configuration
+codeScan:
+  enabled: true           # Enable/Disable the code scan pipeline (true/false)
+  gitleaksFilename: "gitleaks-secrets-report.json"
+  gitleaksSrcDir: "."
+  semgrepFilename: "semgrep-sast-report.json" # Filename for the semgrep sast report (e.g. semgrep-sast-report.json)
+  semgrepRules: "p/default" # Semgrep rules to use (e.g. p/default)
+  semgrepExperimental: false # Whether to use experimental semgrep rules (true/false)
+  coverageFile: "" #"coverage/cobertura-coverage.xml"      # Externally generated code coverage file
+  semgrepSrcDir: "."    # Target directory for semgrep scan (e.g. ./cmd/portage)
+
+# Image Publish Configuration
+imagePublish:
+  enabled: false           # Enable/Disable the image publish pipeline (true/false)
+  bundleTag: "ghcr.io/easy-up/portage-cd:latest"         # Image tag for gatecheck bundle image blob (e.g. my-org/my-app:latest)
+
+# Deploy Configuration
+deploy:
+  enabled: true           # Enable/Disable the deploy pipeline (true/false).  When true, the .gatecheck.yml file is used, otherwise the default gatecheck config is used.
+  gatecheckConfigFilename: ".custom-gatecheck.yml"  # Filename for gatecheck config which specifies the validation rules and limits applied during the deployment process
+  successWebhooks:
+    - url: "http://localhost:5168/Build/SubmitArtifacts"  # Using the same endpoint from .custom-gatecheck.yml for consistency
+      authorizationVar: "DEPLOY_WEBHOOK_AUTH_TOKEN"  # Environment variable containing the auth token

--- a/cmd/portage/cli/v0/pipelines.go
+++ b/cmd/portage/cli/v0/pipelines.go
@@ -143,7 +143,9 @@ func runDeploy(cmd *cobra.Command, _ []string, force bool) error {
 	if err := viper.Unmarshal(config); err != nil {
 		return err
 	}
-	config.Deploy.Enabled = true
+	if force {
+		config.Deploy.Enabled = true
+	}
 	return deployPipeline(cmd.OutOrStdout(), cmd.ErrOrStderr(), config, dryRunEnabled)
 }
 

--- a/pkg/pipelines/code-scan.go
+++ b/pkg/pipelines/code-scan.go
@@ -54,6 +54,14 @@ func (p *CodeScan) preRun() error {
 		return errors.New("code Scan Pipeline failed to run")
 	}
 
+	// Delete existing bundle file if it exists
+	p.runtime.bundleFilename = path.Join(p.config.ArtifactDir, p.config.GatecheckBundleFilename)
+	if err := os.Remove(p.runtime.bundleFilename); err != nil && !errors.Is(err, os.ErrNotExist) {
+		slog.Error("failed to remove existing bundle file", "error", err)
+		return err
+	}
+	slog.Debug("cleaned up existing bundle file if it existed", "bundle", p.runtime.bundleFilename)
+
 	p.runtime.gitleaksFilename = path.Join(p.config.ArtifactDir, p.config.CodeScan.GitleaksFilename)
 	p.runtime.gitleaksFile, err = OpenOrCreateFile(p.runtime.gitleaksFilename)
 	if err != nil {

--- a/pkg/pipelines/deploy.go
+++ b/pkg/pipelines/deploy.go
@@ -63,7 +63,7 @@ func (p *Deploy) Run() error {
 		return errors.New("deploy Pipeline failed, pre-run error. See logs for details")
 	}
 
-	slog.Warn("deployment pipeline is a beta feature. Only gatecheck validation will be conducted.")
+	slog.Warn("Deployments only work with Belay using a valid jwt.")
 
 	gatecheckConfigPath := path.Join(p.config.ArtifactDir, "gatecheck-config.yml")
 	gatecheckConfig, err := os.OpenFile(gatecheckConfigPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)

--- a/pkg/pipelines/helper.go
+++ b/pkg/pipelines/helper.go
@@ -61,22 +61,46 @@ func InitGatecheckBundle(config *Config, stderr io.Writer, dryRunEnabled bool) e
 
 	bundleFilename := path.Join(config.ArtifactDir, config.GatecheckBundleFilename)
 
+	// Check if bundle exists before operations
+	if _, err := os.Stat(bundleFilename); err == nil {
+		slog.Debug("bundle file already exists before initialization", "bundle", bundleFilename)
+	} else if errors.Is(err, os.ErrNotExist) {
+		slog.Debug("bundle file does not exist before initialization", "bundle", bundleFilename)
+	} else {
+		slog.Error("error checking bundle file", "bundle", bundleFilename, "error", err)
+	}
+
 	return AddBundleFile(dryRunEnabled, bundleFilename, tempConfigFilename, stderr)
 }
 
 func AddBundleFile(dryRunEnabled bool, bundleFilename string, filename string, stderr io.Writer) error {
+	slog.Debug("attempting to add file to bundle",
+		"bundle", bundleFilename,
+		"file", filename,
+		"dry_run", dryRunEnabled)
+
+	// Base options that are common for both create and add
 	opts := []shell.OptionFunc{
 		shell.WithDryRun(dryRunEnabled),
 		shell.WithBundleFile(bundleFilename, filename),
-		shell.WithErrorOnly(stderr),
 	}
+
+	// If we're in debug mode (verbose), show all output
+	if slog.Default().Handler().Enabled(nil, slog.LevelDebug) {
+		opts = append(opts, shell.WithStderr(stderr))
+	} else {
+		opts = append(opts, shell.WithErrorOnly(stderr))
+	}
+
 	if _, err := os.Stat(bundleFilename); err != nil {
 		// The bundle file does not exist
 		if errors.Is(err, os.ErrNotExist) {
+			slog.Debug("bundle does not exist, creating new bundle")
 			return shell.GatecheckBundleCreate(opts...)
 		}
 		return err
 	}
 
+	slog.Debug("bundle exists, adding file to existing bundle")
 	return shell.GatecheckBundleAdd(opts...)
 }

--- a/pkg/shell/gatecheck.go
+++ b/pkg/shell/gatecheck.go
@@ -1,6 +1,9 @@
 package shell
 
-import "os/exec"
+import (
+	"log/slog"
+	"os/exec"
+)
 
 // GatecheckVersion print version information
 //
@@ -9,7 +12,11 @@ import "os/exec"
 // Output: to STDOUT
 func GatecheckVersion(options ...OptionFunc) error {
 	o := newOptions(options...)
-	cmd := exec.Command("gatecheck", "version")
+	args := []string{"version"}
+	if o.logger.Handler().Enabled(nil, slog.LevelDebug) {
+		args = append(args, "-v")
+	}
+	cmd := exec.Command("gatecheck", args...)
 	return run(cmd, o)
 }
 
@@ -20,10 +27,15 @@ func GatecheckVersion(options ...OptionFunc) error {
 // Output: table to STDOUT
 func GatecheckList(options ...OptionFunc) error {
 	o := newOptions(options...)
-	cmd := exec.Command("gatecheck", "list", "--input-type", o.reportType)
-	if o.listTargetFilename != "" {
-		cmd = exec.Command("gatecheck", "list", o.listTargetFilename)
+	args := []string{"list", "--input-type", o.reportType}
+	if o.logger.Handler().Enabled(nil, slog.LevelDebug) {
+		args = append(args, "-v")
 	}
+	if o.listTargetFilename != "" {
+		cmd := exec.Command("gatecheck", "list", o.listTargetFilename)
+		return run(cmd, o)
+	}
+	cmd := exec.Command("gatecheck", args...)
 	return run(cmd, o)
 }
 
@@ -34,7 +46,11 @@ func GatecheckList(options ...OptionFunc) error {
 // Output: table to STDOUT
 func GatecheckListAll(options ...OptionFunc) error {
 	o := newOptions(options...)
-	cmd := exec.Command("gatecheck", "list", "--input-type", o.reportType)
+	args := []string{"list", "--input-type", o.reportType}
+	if o.logger.Handler().Enabled(nil, slog.LevelDebug) {
+		args = append(args, "-v")
+	}
+	cmd := exec.Command("gatecheck", args...)
 	return run(cmd, o)
 }
 
@@ -45,8 +61,11 @@ func GatecheckListAll(options ...OptionFunc) error {
 // Output: debug to STDERR
 func GatecheckBundleAdd(options ...OptionFunc) error {
 	o := newOptions(options...)
-	cmd := exec.Command("gatecheck", "bundle", "add",
-		o.gatecheck.bundleFilename, o.gatecheck.targetFile)
+	args := []string{"bundle", "add", o.gatecheck.bundleFilename, o.gatecheck.targetFile}
+	if o.logger.Handler().Enabled(nil, slog.LevelDebug) {
+		args = append(args, "-v")
+	}
+	cmd := exec.Command("gatecheck", args...)
 	return run(cmd, o)
 }
 
@@ -57,8 +76,11 @@ func GatecheckBundleAdd(options ...OptionFunc) error {
 // Output: debug to STDERR
 func GatecheckBundleCreate(options ...OptionFunc) error {
 	o := newOptions(options...)
-	cmd := exec.Command("gatecheck", "bundle", "create",
-		o.gatecheck.bundleFilename, o.gatecheck.targetFile)
+	args := []string{"bundle", "create", o.gatecheck.bundleFilename, o.gatecheck.targetFile}
+	if o.logger.Handler().Enabled(nil, slog.LevelDebug) {
+		args = append(args, "-v")
+	}
+	cmd := exec.Command("gatecheck", args...)
 	return run(cmd, o)
 }
 
@@ -72,6 +94,10 @@ func GatecheckValidate(options ...OptionFunc) error {
 	args := []string{"validate", o.targetFilename}
 	if o.configFilename != "" {
 		args = append(args, "--config", o.configFilename)
+	}
+	// Pass through verbosity flag if portage is in verbose mode
+	if o.logger.Handler().Enabled(nil, slog.LevelDebug) {
+		args = append(args, "-v")
 	}
 	cmd := exec.Command("gatecheck", args...)
 	return run(cmd, o)

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -78,6 +78,8 @@ type Options struct {
 	gatecheck struct {
 		bundleFilename string
 		targetFile     string
+		label          string
+		tags           []string
 	}
 
 	semgrep struct {
@@ -235,6 +237,14 @@ func WithBundleFile(bundleFilename string, targetFilename string) OptionFunc {
 	return func(o *Options) {
 		o.gatecheck.bundleFilename = bundleFilename
 		o.gatecheck.targetFile = targetFilename
+	}
+}
+
+// WithBundleLabel sets the label and optional tags for bundle operations
+func WithBundleLabel(label string, tags ...string) OptionFunc {
+	return func(o *Options) {
+		o.gatecheck.label = label
+		o.gatecheck.tags = tags
 	}
 }
 


### PR DESCRIPTION
Added configuration files to run portage/gatecheck on gatecheck itself.  When running portage run -v all, the verbose logging level was not being passed to gatecheck making debugging harder.  This was fixed because the git context wasn't showing up in the manifest and I needed better debugging.  It turned out that the gatecheck bundle create wasn't being called if the tar.gz file was already there.  Files were being appended & replaced in the existing.  New logic was added to delete the existing bundle for a new portage run all.  Another bug was fixed where the deploy webhook would be called even if the configuration was disabled.  
